### PR TITLE
User (Email, Nickname) validate 뷰에서 request body 받는 부분, response 수정

### DIFF
--- a/scheduler/member/exceptions.py
+++ b/scheduler/member/exceptions.py
@@ -9,7 +9,7 @@ class EmailInvalid(APIException):
 
 
 class EmailBlank(APIException):
-    status_code = status.HTTP_202_ACCEPTED
+    status_code = status.HTTP_404_NOT_FOUND
     default_detail = "이메일 값이 비어있습니다."
     default_code = "email_blank"
 
@@ -27,7 +27,7 @@ class EmailUseful(APIException):
 
 
 class NicknameBlank(APIException):
-    status_code = status.HTTP_202_ACCEPTED
+    status_code = status.HTTP_404_NOT_FOUND
     default_detail = "닉네임 값이 비어있습니다."
     default_code = "nickname_blank"
 

--- a/scheduler/member/exceptions.py
+++ b/scheduler/member/exceptions.py
@@ -8,10 +8,10 @@ class EmailInvalid(APIException):
     default_code = "email_invalid"
 
 
-class EmailRequired(APIException):
+class EmailBlank(APIException):
     status_code = status.HTTP_202_ACCEPTED
     default_detail = "이메일 값이 비어있습니다."
-    default_code = "email_required"
+    default_code = "email_blank"
 
 
 class EmailUnique(APIException):
@@ -26,10 +26,10 @@ class EmailUseful(APIException):
     default_code = "email_useful"
 
 
-class NicknameRequired(APIException):
+class NicknameBlank(APIException):
     status_code = status.HTTP_202_ACCEPTED
     default_detail = "닉네임 값이 비어있습니다."
-    default_code = "nickname_required"
+    default_code = "nickname_blank"
 
 
 class NicknameMaxLength(APIException):

--- a/scheduler/member/exceptions.py
+++ b/scheduler/member/exceptions.py
@@ -1,0 +1,50 @@
+from rest_framework.exceptions import APIException
+from rest_framework import status
+
+
+class EmailInvalid(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "이메일이 형식에 맞지 않습니다."
+    default_code = "email_invalid"
+
+
+class EmailRequired(APIException):
+    status_code = status.HTTP_202_ACCEPTED
+    default_detail = "이메일 값이 비어있습니다."
+    default_code = "email_required"
+
+
+class EmailUnique(APIException):
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = "이미 사용 중인 이메일입니다."
+    default_code = "email_unique"
+
+
+class EmailUseful(APIException):
+    status_code = status.HTTP_200_OK
+    default_detail = "사용 가능한 이메일입니다."
+    default_code = "email_useful"
+
+
+class NicknameRequired(APIException):
+    status_code = status.HTTP_202_ACCEPTED
+    default_detail = "닉네임 값이 비어있습니다."
+    default_code = "nickname_required"
+
+
+class NicknameMaxLength(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "닉네임의 최대 길이는 30자입니다."
+    default_code = "nickname_max_length"
+
+
+class NicknameUnique(APIException):
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = "이미 사용 중인 닉네임입니다."
+    default_code = "nickname_unique"
+
+
+class NicknameUseful(APIException):
+    status_code = status.HTTP_200_OK
+    default_detail = "사용 가능한 닉네임입니다."
+    default_code = "nickname_useful"

--- a/scheduler/member/serializers.py
+++ b/scheduler/member/serializers.py
@@ -63,3 +63,15 @@ class FriendRequestSerializer(serializers.ModelSerializer):
     class Meta:
         model = FriendRequest
         fields = ('request_user', 'response_user', )
+
+
+class EmailValidateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('email', )
+
+
+class NicknameValidateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('nickname', )

--- a/scheduler/member/views.py
+++ b/scheduler/member/views.py
@@ -89,6 +89,27 @@ class UserProfileViewSet(viewsets.GenericViewSet,
                 'user': user_data,
             }, status=status.HTTP_200_OK)
 
+    @action(detail=True)
+    def friend_list(self, request, pk=None):
+        try:
+            user = UserProfile.objects.get(user__id=pk)
+        except UserProfile.DoesNotExist:
+            return Response({
+                'success': False,
+                'data': {
+                    'message': 'User not found'
+                }
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        friends_serializer = user.friends.values_list('pk', flat=True)
+
+        return Response({
+            'success': True,
+            'data': {
+                'friends': friends_serializer
+            }
+        }, status=status.HTTP_200_OK)
+
 
 @api_view(['GET'])
 def user_email_validate(request):
@@ -190,27 +211,3 @@ class FriendRequestViewSet(viewsets.GenericViewSet,
             return Response({
                 'message': '친구 요청 수락',
             }, status=status.HTTP_200_OK)
-
-    @action(detail=True)
-    def friend_list(self, request, pk=None):
-        try:
-            user = UserProfile.objects.get(user__id=pk)
-        except UserProfile.DoesNotExist:
-            return Response({
-                'success': False,
-                'data': {
-                    'message': 'User not found'
-                }
-            }, status=status.HTTP_400_BAD_REQUEST)
-
-        friends_serializer = []
-
-        for friend in user.friends.all():
-            friends_serializer.append(friend.pk)
-
-        return Response({
-            'success': True,
-            'data': {
-                'friends': friends_serializer
-            }
-        }, status=status.HTTP_200_OK)

--- a/scheduler/member/views.py
+++ b/scheduler/member/views.py
@@ -122,7 +122,6 @@ def user_nickname_validate(request):
     try:
         serializer.is_valid(raise_exception=True)
     except ValidationError:
-        print(serializer.errors)
         if serializer.errors['nickname'][0] == "user with this nickname already exists.":
             raise NicknameUnique()
         elif serializer.errors['nickname'][0] == "This field may not be blank.":

--- a/scheduler/member/views.py
+++ b/scheduler/member/views.py
@@ -190,3 +190,27 @@ class FriendRequestViewSet(viewsets.GenericViewSet,
             return Response({
                 'message': '친구 요청 수락',
             }, status=status.HTTP_200_OK)
+
+    @action(detail=True)
+    def friend_list(self, request, pk=None):
+        try:
+            user = UserProfile.objects.get(user__id=pk)
+        except UserProfile.DoesNotExist:
+            return Response({
+                'success': False,
+                'data': {
+                    'message': 'User not found'
+                }
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        friends_serializer = []
+
+        for friend in user.friends.all():
+            friends_serializer.append(friend.pk)
+
+        return Response({
+            'success': True,
+            'data': {
+                'friends': friends_serializer
+            }
+        }, status=status.HTTP_200_OK)


### PR DESCRIPTION
member/views.py
 - MOD: request.POST.get('email') -> request.data['email']
 - MOD: request.POST.get('nickname') -> request.data['nickname']
 - ADD: serializer.is_valid() 작업 후 message에 따라 APIException 작동
 - MOD: (Email, Nickname) 닉네임 사용 여부의 response status code가 반대로 되어있어 변경

member/exceptions.py
 - ADD: email_validation에 대한 APIException 작성 (Invalid, Required, Unique, Useful)
 - ADD: nickname_validation에 대한 APIException 작성 (Required, MaxLength, Unique, Useful)

PS: 저도 현재 방법이 마음에 들지 않은데 리뷰를 받고 고치는게 나아서 PR 넣어봤습니다...ㅠㅠ