### PR TITLE
Set 'ACCOUNT_USER_MODEL_USERNAME_FIELD' in socialaccount

### DIFF
--- a/scheduler/scheduler/settings.py
+++ b/scheduler/scheduler/settings.py
@@ -131,6 +131,8 @@ INTERNAL_IPS = '127.0.0.1'
 
 AUTH_USER_MODEL = 'member.User'
 
+ACCOUNT_USER_MODEL_USERNAME_FIELD = "email"
+
 SITE_ID = 1
 
 import local_settings


### PR DESCRIPTION
 - Member 앱의 User model을 migrate 하기 위하여 socialaccount 이 기본적으로 설정하고 있는 'ACCOUNT_USER_MODEL_USERNAME_FIELD'를 'username'에서 'email'로 변경하였습니다.